### PR TITLE
fix: add apex domain as SAN on wildcard certificate

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ export class WildcardCertConstruct extends Construct {
       `${id}-DnsValidatedCertificate`,
       {
         domainName: `*.${props.domainName}`,
+        subjectAlternativeNames: [props.domainName],
         hostedZone: zone,
         region: props.region || 'us-east-1', // Cloudfront only checks this region for certificates.
       },


### PR DESCRIPTION
## Summary
- Add `mattgilbride.com` as a Subject Alternative Name on the wildcard certificate (`*.mattgilbride.com`)
- Wildcard certs don't cover the bare apex domain, causing HTTPS warnings when visiting `mattgilbride.com` directly
- This is step 1 of 2 to fix apex HTTPS — step 2 (in the `mattgilbride` repo) will add the apex domain to CloudFront and update the DNS A record

## Test plan
- [x] `make synth` succeeds
- [x] `make deploy` succeeds — new cert issued with both SANs
- [x] Verified cert covers `*.mattgilbride.com` and `mattgilbride.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)